### PR TITLE
Fixed naming of events in nice things to know.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can try the [live demo](http://edenspiekermann.github.io/a11y-dialog/).
 - Possibility to have several different dialog windows on the page;
 - DOM API (`data-a11y-dialog-show="dialog-id"`, `data-a11y-dialog-hide`);
 - JS API (`dialog.show()`, `dialog.hide()`, `dialog.destroy()`, `dialog.shown`);
-- DOM events (`dialog:open`, `dialog:close`);
+- DOM events (`dialog:show`, `dialog:hide`);
 - No `display` manipulation in JS, the hiding mechanism is entirely up to the CSS layer (using `[aria-hidden]` selectors);
 - Full test coverage with [CasperJS](http://casperjs.org) and [CodeShip](https://codeship.com);
 - Clean code resulting in only 940 bytes (0.94Kb!) once gzipped.


### PR DESCRIPTION
The naming of the events in the nice things to know section seemed to be outdated.

This pull requests update the names to the new? ones. 