### PR TITLE
Don't execute show/hide when already in the desired state

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -108,6 +108,10 @@
     }
 
     function show () {
+      if (that.shown) {
+        return;
+      }
+
       that.shown = true;
       node.removeAttribute('aria-hidden');
       main.setAttribute('aria-hidden', 'true');
@@ -119,6 +123,10 @@
     }
 
     function hide () {
+      if (!that.shown) {
+        return;
+      }
+
       that.shown = false;
       node.setAttribute('aria-hidden', 'true');
       main.removeAttribute('aria-hidden');


### PR DESCRIPTION
I did have the problem that `destroy()` would end in an recursion because I was listening for the `dialog:hide` event and called `destroy` again.

First I wanted to fix it in destroy to check if the dialog is already hidden, but I think it's better to not execute something if it's not needed.

Feedback is very much welcome. :)