### PR TITLE
Add aria-label for dialog-close button in example page in master branch

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -40,7 +40,7 @@
             <input type="email" name="EMAIL" id="email" placeholder="john.doe@gmail.com" required>
             <button type="submit" name="button">Sign up</button>
           </form>
-          <button data-a11y-dialog-hide class="dialog-close" title="Close registration form">&times;</button>
+          <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The close button on the `examples/index.html` page uses a `&times;` entity and a title attribute.

ChromeVox announces the button as "multiplication, button". The title attribute is not announced.

The code snippet in the repo's main README is well documented and uses aria-label for the close button, so it looks like this was just an omission in the live demo version.

This PR replaces the title attribute with aria-label, bringing the live demo example page into line with the recommendation on the README page.