### PR TITLE
Added git repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "focus"
   ],
   "author": "Hugo Giraudel (www.edenspiekermann.com/people/hugo-giraudel)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/edenspiekermann/a11y-dialog"
+  },
   "files": [
     "a11y-dialog.js",
     "a11y-dialog.min.js"


### PR DESCRIPTION
The a11y namespace is a bit crowded on github, so navigating from https://www.npmjs.com/package/a11y-dialog to this repository took a while longer than I wanted it to