### PR TITLE
Fixed global context to ensure platform compatibility

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -399,4 +399,4 @@
   } else if (typeof global === 'object') {
     global.A11yDialog = A11yDialog;
   }
-}(this));
+}(typeof global !== "undefined" ? global : window));


### PR DESCRIPTION
> in certain contexts (e.g. when bundling with Rollup), top-level `this`
> does _not_ correspond to the global object (typically `window`) - so we
> use the more explicit `global` instead, with `window` as fallback
> 
> details: http://2ality.com/2016/09/global.html

dd358effccdd758c6f256eba867f8165d29c81a6

Note that I have _not_ updated the minified version because it seemed like that only happens when a new release is created.