### PR TITLE
Fix modal position to center

### DIFF
--- a/example/styles.css
+++ b/example/styles.css
@@ -49,6 +49,7 @@ dialog::backdrop {
   -webkit-transform: translate(-50%, -50%);
   -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
+  margin: 0;
 }
 
 /* -------------------------------------------------------------------------- *\


### PR DESCRIPTION
Because default value for dialog's `margin` is `auto`.