### PR TITLE
Allow focus on <audio> and <video> elements when dialog is shown

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -11,6 +11,8 @@
     'textarea:not([disabled]):not([inert])',
     'button:not([disabled]):not([inert])',
     'iframe:not([tabindex^="-"]):not([inert])',
+    'audio:not([tabindex^="-"]):not([inert])',
+    'video:not([tabindex^="-"]):not([inert])',
     '[contenteditable]:not([tabindex^="-"]):not([inert])',
     '[tabindex]:not([tabindex^="-"]):not([inert])'
   ];


### PR DESCRIPTION
`<audio>` and `<video>` elements are keyboard focusable and should therefore gain focus if they appear before any other focusable elements in the dialog element.