### PR TITLE
Adds documentation on existing library implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [a11y-dialog](http://edenspiekermann.github.io/a11y-dialog/) is a lightweight (1.3Kb) yet flexible script to create accessible dialog windows.
 
-✔︎ No dependencies
-✔︎ Leveraging the native `<dialog>` element
-✔︎ Closing dialog on overlay click and <kbd>ESC</kbd>
-✔︎ Toggling `aria-*` attributes
-✔︎ Trapping and restoring focus
-✔︎ Firing events
-✔︎ DOM and JS APIs
-✔︎ Fast and tiny
+✔︎ No dependencies  
+✔︎ Leveraging the native `<dialog>` element  
+✔︎ Closing dialog on overlay click and <kbd>ESC</kbd>  
+✔︎ Toggling `aria-*` attributes  
+✔︎ Trapping and restoring focus  
+✔︎ Firing events  
+✔︎ DOM and JS APIs  
+✔︎ Fast and tiny  
 
 You can try the [live demo ↗](http://edenspiekermann.github.io/a11y-dialog/example/).
 
@@ -242,7 +242,7 @@ Nested dialogs is a [questionable design pattern](https://ux.stackexchange.com/q
 
 ## Implementations
 
-If you happen to work with [React.js](https://github.com/facebook/react/) or [Vue.js](https://github.com/vuejs/vue) in your project, you're lucky! There are already great light-weight wrapper implemented for `a11y-dialog`:
+If you happen to work with [React](https://github.com/facebook/react/) or [Vue](https://github.com/vuejs/vue) in your project, you're lucky! There are already great light-weight wrapper implemented for a11y-dialog:
 
 - [React A11yDialog](https://github.com/HugoGiraudel/react-a11y-dialog)
 - [Vue A11yDialog](https://github.com/morkro/vue-a11y-dialog)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [a11y-dialog](http://edenspiekermann.github.io/a11y-dialog/) is a lightweight (1.3Kb) yet flexible script to create accessible dialog windows.
 
-✔︎ No dependencies  
-✔︎ Leveraging the native `<dialog>` element  
-✔︎ Closing dialog on overlay click and <kbd>ESC</kbd>  
-✔︎ Toggling `aria-*` attributes  
-✔︎ Trapping and restoring focus  
-✔︎ Firing events  
-✔︎ DOM and JS APIs  
-✔︎ Fast and tiny  
+✔︎ No dependencies
+✔︎ Leveraging the native `<dialog>` element
+✔︎ Closing dialog on overlay click and <kbd>ESC</kbd>
+✔︎ Toggling `aria-*` attributes
+✔︎ Trapping and restoring focus
+✔︎ Firing events
+✔︎ DOM and JS APIs
+✔︎ Fast and tiny
 
 You can try the [live demo ↗](http://edenspiekermann.github.io/a11y-dialog/example/).
 
@@ -239,6 +239,13 @@ dialog.off('show', doSomething);
 ## Nested dialogs
 
 Nested dialogs is a [questionable design pattern](https://ux.stackexchange.com/questions/52042/is-it-acceptable-to-open-a-modal-popup-on-top-of-another-modal-popup) that is not referenced anywhere in the [HTML 5.2 Dialog specification](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element). Therefore it is discouraged and not supported by default by the library. That being said, if you still want to run with it, [Renato de Leão explains how in edenspiekermann/a11y-dialog#80](https://github.com/edenspiekermann/a11y-dialog/issues/80#issuecomment-377691629).
+
+## Implementations
+
+If you happen to work with [React.js](https://github.com/facebook/react/) or [Vue.js](https://github.com/vuejs/vue) in your project, you're lucky! There are already great light-weight wrapper implemented for `a11y-dialog`:
+
+- [React A11yDialog](https://github.com/HugoGiraudel/react-a11y-dialog)
+- [Vue A11yDialog](https://github.com/morkro/vue-a11y-dialog)
 
 ## Disclaimer & credits
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Nested dialogs is a [questionable design pattern](https://ux.stackexchange.com/q
 
 ## Implementations
 
-If you happen to work with [React](https://github.com/facebook/react/) or [Vue](https://github.com/vuejs/vue) in your project, you're lucky! There are already great light-weight wrapper implemented for a11y-dialog:
+If you happen to work with [React](https://github.com/facebook/react/) or [Vue](https://github.com/vuejs/vue) in your project, you’re lucky! There are already great light-weight wrapper implemented for a11y-dialog:
 
 - [React A11yDialog](https://github.com/HugoGiraudel/react-a11y-dialog)
 - [Vue A11yDialog](https://github.com/morkro/vue-a11y-dialog)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -24,6 +24,9 @@
 * [Nested dialogs](README.md#nested-dialogs)
 
 
+* [Implementations](README.md#implementations)
+
+
 * [Example ↗](http://edenspiekermann.github.io/a11y-dialog/example/)
 
 


### PR DESCRIPTION
Hey :wave: 

I thought to add a short section on existing implementations of `a11y-dialog`, so users don't have to re-implement it again if they happen to use one of the listed libraries.

What do you think?