### PR TITLE
Add support for role='alertdialog'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,9 @@ Here is the basic markup, which can be enhanced. Pay extra attention to the comm
   <!--
     Dialog window content related notes:
     - It is the actual visual dialog element.
-    - It may have the `alertdialog` role to make it 'modal'.
+    - It may have the `alertdialog` role to make it behave like a “modal”. See the “Usage as a modal” section of the docs.
     - It doesn’t have to be a `<dialog>` element, it can be a `<div>` element with the `dialog` or `alertdialog` role (e.g. `<div role="dialog">`).
     - It doesn’t have to have the `aria-labelledby` attribute however this is recommended. It should match the `id` of the dialog title.
-    
-    Regarding the use of the `alertdialog` role:
-    - The dialog won't close when pressing the `esc` key.
-    - You should remove the `data-a11y-dialog-hide` attribute from the Overlay to comply with the WAI-ARIA Recommendation.
-    - You should consider removing the close button below if the dialog can or needs to receive a response from the user.
-    - See https://www.w3.org/TR/wai-aria-1.1/#alertdialog for details.
   -->
   <dialog aria-labelledby="dialog-title">
     <!--
@@ -150,6 +144,18 @@ As recommended in the [HTML section](#expected-dom-structure) of this documentat
 ```javascript
 const dialog = new A11yDialog(el, containers);
 ```
+
+### Usage as a “modal”
+
+By default, a11y-dialog behaves as a dialog: it is closable with the <kbd>ESC</kbd> key, and by clicking the backdrop. However, it is possible to make it work like a “modal”, which would remove these features.
+
+To do so:
+
+1. Add `role="alertdialog"` to the `<dialog>` element or replace`role="dialog"` with `role="alertdialog"` in case you don’t use the `<dialog>` element. This will make sure <kbd>ESC</kbd> doesn’t close the modal.
+2. Remove `data-a11y-dialog-hide` from the overlay element. This makes sure it is not possible to close the modal by clicking outside of it.
+3. In case the user actively needs to operate with the modal, you might consider removing the close button from it. Be sure to still offer a way to eventually close the modal.
+
+For more information about modals, refer to the [WAI ARIA recommendations](https://www.w3.org/TR/wai-aria-1.1/#alertdialog).
 
 ## DOM API
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,15 @@ Here is the basic markup, which can be enhanced. Pay extra attention to the comm
   <!--
     Dialog window content related notes:
     - It is the actual visual dialog element.
-    - It doesn’t have to be a `<dialog>` element, it can be a `<div>` element with the `dialog` role (e.g. `<div role="dialog">`).
+    - It may have the `alertdialog` role to make it 'modal'.
+    - It doesn’t have to be a `<dialog>` element, it can be a `<div>` element with the `dialog` or `alertdialog` role (e.g. `<div role="dialog">`).
     - It doesn’t have to have the `aria-labelledby` attribute however this is recommended. It should match the `id` of the dialog title.
+    
+    Regarding the use of the `alertdialog` role:
+    - The dialog won't close when pressing the `esc` key.
+    - You should remove the `data-a11y-dialog-hide` attribute from the Overlay to comply with the WAI-ARIA Recommendation.
+    - You should consider removing the close button below if the dialog can or needs to receive a response from the user.
+    - See https://www.w3.org/TR/wai-aria-1.1/#alertdialog for details.
   -->
   <dialog aria-labelledby="dialog-title">
     <!--

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -37,7 +37,8 @@
 
     // Keep a reference of the node and the actual dialog on the instance
     this.container = node;
-    this.dialog = node.querySelector('dialog, [role="dialog"]');
+    this.dialog = node.querySelector('dialog, [role="dialog"], [role="alertdialog"]');
+    this.role = this.dialog.getAttribute('role') || 'dialog';
     this.useDialog = (
       'show' in document.createElement('dialog') &&
       this.dialog.nodeName === 'DIALOG'
@@ -67,7 +68,7 @@
     // Despite using a `<dialog>` element, `role="dialog"` is not necessarily
     // implied by all screen-readers (yet)
     // See: https://github.com/edenspiekermann/a11y-dialog/commit/6ba711a777aed0dbda0719a18a02f742098c64d9#commitcomment-28694166
-    this.dialog.setAttribute('role', 'dialog');
+    this.dialog.setAttribute('role', this.role);
 
     if (!this.useDialog) {
       if (this.shown) {
@@ -291,8 +292,9 @@
    */
   A11yDialog.prototype._bindKeypress = function(event) {
     // If the dialog is shown and the ESCAPE key is being pressed, prevent any
-    // further effects from the ESCAPE key and hide the dialog
-    if (this.shown && event.which === ESCAPE_KEY) {
+    // further effects from the ESCAPE key and hide the dialog, unless its role
+    // is 'alertdialog', which should be modal
+    if (this.shown && event.which === ESCAPE_KEY && this.role !== 'alertdialog') {
       event.preventDefault();
       this.hide();
     }

--- a/tests/index.html
+++ b/tests/index.html
@@ -56,6 +56,16 @@
       </div>
     </div>
 
+    <div class="test" id="test-KEY_PRESSES_ALERTDIALOG">
+      <div class="main target">Main</div>
+      <div class="dialog">
+        <dialog role='alertdialog'>
+          <h1 class="dialog-title" tabindex="0">Dialog Title</h1>
+          <button class="close-button" data-a11y-dialog-hide>&times;</button>
+        </dialog>
+      </div>
+    </div>
+
     <div class="test" id="test-CREATE">
       <div class="main target">
         <button data-a11y-dialog-show="dialog-DESTROY">Open</button>

--- a/tests/index.js
+++ b/tests/index.js
@@ -301,6 +301,21 @@ describe('A11yDialog', () => {
       expect(document.activeElement).to.eql(window.scope.closeButton);
     });
   });
+
+  describe('When listening to key presses on role="alertdialog", it…', () => {
+    before(() => {
+      setup(document.querySelector('#test-KEY_PRESSES_ALERTDIALOG'));
+    });
+
+    after(teardown);
+
+    it('should NOT close dialog on ESC', () => {
+      window.scope.instance.show();
+      keydown(27);
+
+      expect(window.scope.instance.shown).to.eql(true);
+    });
+  });
 });
 
 function keydown(k, shift) {


### PR DESCRIPTION
First time contributor. Posting for feedback before jumping into tests, docs and examples. Hopefully its a small, non-breaking change.

Adds support for role='alertdialog', making the dialog modal by not closing it when the escape key is pressed. Note that the `data-a11y-dialog-hide` attribute should be removed from the overlay as well to comply with the specification.

Closes  #83.