### PR TITLE
Remove event param passed to native dialog methods

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -127,7 +127,7 @@
     focusedBeforeDialog = document.activeElement;
 
     if (this.useDialog) {
-      this.dialog.showModal(event instanceof Event ? void 0 : event);
+      this.dialog.showModal();
     } else {
       this.dialog.setAttribute('open', '');
       this.container.removeAttribute('aria-hidden');
@@ -171,7 +171,7 @@
     this.shown = false;
 
     if (this.useDialog) {
-      this.dialog.close(event instanceof Event ? void 0 : event);
+      this.dialog.close();
     } else {
       this.dialog.removeAttribute('open');
       this.container.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
Hi,

in all the latest specs and docs I could find, the `.showModal()` method does not accept any param. 
The `.close()` method does not accept an `event` param but a `returnValue: string`.  

Also the ternary was dubious: `event instanceof Event ? void 0 : event`.


NB: discovered while creating this library Flow definitions: https://github.com/flow-typed/flow-typed/pull/2756
