### PR TITLE
Allow access to the escape key event from listeners

### DIFF
--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -296,7 +296,7 @@
     // is 'alertdialog', which should be modal
     if (this.shown && event.which === ESCAPE_KEY && this.role !== 'alertdialog') {
       event.preventDefault();
-      this.hide();
+      this.hide(event);
     }
 
     // If the dialog is shown and the TAB key is being pressed, make sure the


### PR DESCRIPTION
Hello!

I'm trying to access the **Escape key** keydown event from the `hide` listener. 

```js
mydialog.on('hide': (elem, evt) => {
  // evt: undefined
});
```



This little patch should fix it.



