### PR TITLE
Additional aria-hidden handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Here is the basic markup, which can be enhanced. Pay extra attention to the comm
   Dialog container related notes:
   - It is not the actual dialog window, just the container with which the script interacts.
   - It can have a different id than `my-accessible-dialog`, but it needs an `id` anyway.
-  - It can have a different class, or no class at all - as long as your CSS accounts for that
-  - We recommend adding an initial `aria-hidden="true"` to avoid a "flash of unhidden dialog" on page load
+  - It can have a different class, or no class at all—as long as your CSS accounts for that.
+  - It should have an initial `aria-hidden="true"` to avoid a “flash of unhidden dialog” on page load.
 -->
 <div class="dialog-container" id="my-accessible-dialog" aria-hidden="true">
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Here is the basic markup, which can be enhanced. Pay extra attention to the comm
 <!--
   Dialog container related notes:
   - It is not the actual dialog window, just the container with which the script interacts.
-  - It can have a different id than `my-accessible-dialog`, but it needs an `id`
-  anyway.
+  - It can have a different id than `my-accessible-dialog`, but it needs an `id` anyway.
+  - It can have a different class, or no class at all - as long as your CSS accounts for that
+  - We recommend adding an initial `aria-hidden="true"` to avoid a "flash of unhidden dialog" on page load
 -->
-<div id="my-accessible-dialog">
+<div class="dialog-container" id="my-accessible-dialog" aria-hidden="true">
 
   <!--
     Overlay related notes:

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -78,6 +78,8 @@
       }
     } else {
       this.container.setAttribute('data-a11y-dialog-native', '');
+      // Remove initial `aria-hidden` from container
+      // See: https://github.com/edenspiekermann/a11y-dialog/pull/117#issuecomment-706056246
       this.container.removeAttribute('aria-hidden');
     }
 

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -133,7 +133,7 @@
       this.dialog.setAttribute('open', '');
 
       // Iterate over the targets to disable them by setting their `aria-hidden`
-      // attribute to `true`
+      // attribute to `true` and, if present, storing the current value of `aria-hidden`
       this._targets.forEach(function(target) {
         if (target.getAttribute('aria-hidden')) {
           target.setAttribute('data-a11y-dialog-original-aria-hidden', target.getAttribute('aria-hidden'));
@@ -180,7 +180,7 @@
       this.container.setAttribute('aria-hidden', 'true');
 
       // Iterate over the targets to enable them by removing their `aria-hidden`
-      // attribute
+      // attribute or resetting it to its original value
       this._targets.forEach(function(target) {
         if (target.getAttribute('data-a11y-dialog-original-aria-hidden')) {
           target.setAttribute('aria-hidden', target.getAttribute('data-a11y-dialog-original-aria-hidden'));

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -135,7 +135,7 @@
       // Iterate over the targets to disable them by setting their `aria-hidden`
       // attribute to `true` and, if present, storing the current value of `aria-hidden`
       this._targets.forEach(function(target) {
-        if (target.getAttribute('aria-hidden')) {
+        if (target.hasAttribute('aria-hidden')) {
           target.setAttribute('data-a11y-dialog-original-aria-hidden', target.getAttribute('aria-hidden'));
         }
         target.setAttribute('aria-hidden', 'true');
@@ -182,7 +182,7 @@
       // Iterate over the targets to enable them by removing their `aria-hidden`
       // attribute or resetting it to its original value
       this._targets.forEach(function(target) {
-        if (target.getAttribute('data-a11y-dialog-original-aria-hidden')) {
+        if (target.hasAttribute('data-a11y-dialog-original-aria-hidden')) {
           target.setAttribute('aria-hidden', target.getAttribute('data-a11y-dialog-original-aria-hidden'));
           target.removeAttribute('data-a11y-dialog-original-aria-hidden');
         } else {

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -126,11 +126,14 @@
     // it later
     focusedBeforeDialog = document.activeElement;
 
+    if (this.container.getAttribute('aria-hidden')) {
+      this.container.removeAttribute('aria-hidden');
+    }
+
     if (this.useDialog) {
       this.dialog.showModal(event instanceof Event ? void 0 : event);
     } else {
       this.dialog.setAttribute('open', '');
-      this.container.removeAttribute('aria-hidden');
 
       // Iterate over the targets to disable them by setting their `aria-hidden`
       // attribute to `true`

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -78,6 +78,7 @@
       }
     } else {
       this.container.setAttribute('data-a11y-dialog-native', '');
+      this.container.removeAttribute('aria-hidden');
     }
 
     // Keep a collection of dialog openers, each of which will be bound a click
@@ -125,10 +126,6 @@
     // Keep a reference to the currently focused element to be able to restore
     // it later
     focusedBeforeDialog = document.activeElement;
-
-    if (this.container.getAttribute('aria-hidden')) {
-      this.container.removeAttribute('aria-hidden');
-    }
 
     if (this.useDialog) {
       this.dialog.showModal(event instanceof Event ? void 0 : event);

--- a/a11y-dialog.js
+++ b/a11y-dialog.js
@@ -135,6 +135,9 @@
       // Iterate over the targets to disable them by setting their `aria-hidden`
       // attribute to `true`
       this._targets.forEach(function(target) {
+        if (target.getAttribute('aria-hidden')) {
+          target.setAttribute('data-a11y-dialog-original-aria-hidden', target.getAttribute('aria-hidden'));
+        }
         target.setAttribute('aria-hidden', 'true');
       });
     }
@@ -179,7 +182,12 @@
       // Iterate over the targets to enable them by removing their `aria-hidden`
       // attribute
       this._targets.forEach(function(target) {
-        target.removeAttribute('aria-hidden');
+        if (target.getAttribute('data-a11y-dialog-original-aria-hidden')) {
+          target.setAttribute('aria-hidden', target.getAttribute('data-a11y-dialog-original-aria-hidden'));
+          target.removeAttribute('data-a11y-dialog-original-aria-hidden');
+        } else {
+          target.removeAttribute('aria-hidden');
+        }
       });
     }
 

--- a/example/index.html
+++ b/example/index.html
@@ -27,7 +27,7 @@
       </footer>
     </div>
 
-    <div class="dialog" id="my-accessible-dialog">
+    <div class="dialog" id="my-accessible-dialog" aria-hidden="true">
       <div class="dialog-overlay" tabindex="-1" data-a11y-dialog-hide></div>
       <dialog class="dialog-content" aria-labelledby="dialogTitle" aria-describedby="dialogDescription">
         <button data-a11y-dialog-hide class="dialog-close" aria-label="Close this dialog window">&times;</button>

--- a/example/main.js
+++ b/example/main.js
@@ -78,6 +78,7 @@
       }
     } else {
       this.container.setAttribute('data-a11y-dialog-native', '');
+      this.container.removeAttribute('aria-hidden');
     }
 
     // Keep a collection of dialog openers, each of which will be bound a click
@@ -130,11 +131,13 @@
       this.dialog.showModal(event instanceof Event ? void 0 : event);
     } else {
       this.dialog.setAttribute('open', '');
-      this.container.removeAttribute('aria-hidden');
 
       // Iterate over the targets to disable them by setting their `aria-hidden`
-      // attribute to `true`
+      // attribute to `true` and, if present, storing the current value of `aria-hidden`
       this._targets.forEach(function(target) {
+        if (target.hasAttribute('aria-hidden')) {
+          target.setAttribute('data-a11y-dialog-original-aria-hidden', target.getAttribute('aria-hidden'));
+        }
         target.setAttribute('aria-hidden', 'true');
       });
     }
@@ -177,9 +180,14 @@
       this.container.setAttribute('aria-hidden', 'true');
 
       // Iterate over the targets to enable them by removing their `aria-hidden`
-      // attribute
+      // attribute or resetting it to its original value
       this._targets.forEach(function(target) {
-        target.removeAttribute('aria-hidden');
+        if (target.hasAttribute('data-a11y-dialog-original-aria-hidden')) {
+          target.setAttribute('aria-hidden', target.getAttribute('data-a11y-dialog-original-aria-hidden'));
+          target.removeAttribute('data-a11y-dialog-original-aria-hidden');
+        } else {
+          target.removeAttribute('aria-hidden');
+        }
       });
     }
 


### PR DESCRIPTION
- if any sibling elements/containers already have `aria-hidden`, stores that value when the dialog is opened and restores it after the dialog is closed (prevents that on closing the dialog all of a sudden other things that were already meant to be/stay `aria-hidden` suddenly become unhidden)
- removes `aria-hidden`, if present, when the dialog is instantiated - authors may already have `aria-hidden` present to avoid a "flash of unhidden dialog" on page load (for slow-loading/heavy processing pages, the dialog is otherwise visible, and covers the page, until the JS kicks in to hide it)