### PR TITLE
Add tests for recent changes

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -68,9 +68,9 @@
 
     <div class="test" id="test-CREATE">
       <div class="main target">
-        <button data-a11y-dialog-show="dialog-DESTROY">Open</button>
+        <button data-a11y-dialog-show="dialog-CREATE">Open</button>
       </div>
-      <div class="dialog" id="dialog-DESTROY">
+      <div class="dialog" id="dialog-CREATE" aria-hidden="true">
         <dialog>
           <button data-a11y-dialog-hide>Close</button>
         </dialog>
@@ -79,9 +79,9 @@
 
     <div class="test" id="test-SHOW">
       <div class="main target">
-        <button data-a11y-dialog-show="dialog-DESTROY">Open</button>
+        <button data-a11y-dialog-show="dialog-SHOW">Open</button>
       </div>
-      <div class="dialog" id="dialog-DESTROY">
+      <div class="dialog" id="dialog-SHOW">
         <dialog>
           <button data-a11y-dialog-hide>Close</button>
         </dialog>
@@ -89,15 +89,39 @@
       <div class="secondary target"></div>
     </div>
 
-    <div class="test" id="test-HIDE">
+    <div class="test" id="test-SHOW-SIBLINGS">
       <div class="main target">
-        <button data-a11y-dialog-show="dialog-DESTROY">Open</button>
+        <button data-a11y-dialog-show="dialog-SHOW-SIBLINGS">Open</button>
       </div>
-      <div class="dialog" id="dialog-DESTROY">
+      <div class="dialog" id="dialog-SHOW-SIBLINGS">
         <dialog>
           <button data-a11y-dialog-hide>Close</button>
         </dialog>
       </div>
+      <div class="secondary alreadyhidden target" aria-hidden="true"></div>
+    </div>
+
+    <div class="test" id="test-HIDE">
+      <div class="main target">
+        <button data-a11y-dialog-show="dialog-HIDE">Open</button>
+      </div>
+      <div class="dialog" id="dialog-HIDE">
+        <dialog>
+          <button data-a11y-dialog-hide>Close</button>
+        </dialog>
+      </div>
+    </div>
+
+    <div class="test" id="test-HIDE-SIBLINGS">
+      <div class="main target">
+        <button data-a11y-dialog-show="dialog-HIDE-SIBLINGS">Open</button>
+      </div>
+      <div class="dialog" id="dialog-HIDE-SIBLINGS">
+        <dialog>
+          <button data-a11y-dialog-hide>Close</button>
+        </dialog>
+      </div>
+      <div class="alreadyhidden target" aria-hidden="true"></div>
     </div>
 
     <div class="test" id="test-DESTROY">


### PR DESCRIPTION
- checks the initial removal of `aria-hidden` if `<dialog>` is natively supported (to check that it does the "flash of unhidden dialog" swap of `aria-hidden` for `data-a11y-dialog-native`)
- checks that `aria-hidden` state of siblings (for these tests, explicitly marked as "targets") is stored in `data-a11y-dialog-original-aria-hidden` on show when `<dialog>` is not natively supported
- checks that `data-a11y-dialog-original-aria-hidden` is removed and `aria-hidden` is reset to original value on siblings (for these tests, explicitly marked as "targets") when hiding and when `<dialog>` is not natively supported
- correct non-unique / nonsensical `id` attributes and related `data-a11y-dialog-show` values in the tests (as they were not unique and clearly copy-pasted from the last one without correction)