### PR TITLE
Adds prefers-reduced-motion for cypress fixtures

### DIFF
--- a/cypress/fixtures/styles.css
+++ b/cypress/fixtures/styles.css
@@ -124,6 +124,15 @@ dialog.dialog-content {
   transition: 0.15s;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .dialog-close {
+    transition: none;
+  }
+  .dialog-content {
+    animation: none;
+  }
+}
+
 @media screen and (min-width: 700px) {
   .dialog-close {
     top: 1em;


### PR DESCRIPTION
This possibly should be to be duplicated into whatever repo the docs / site lives in (and the example codepen too) if we agree with this change.