### PR TITLE
Fix: Correct ordering of operations on dialog hide

### DIFF
--- a/src/a11y-dialog.ts
+++ b/src/a11y-dialog.ts
@@ -126,15 +126,15 @@ export default class A11yDialog {
     this.shown = false
     this.$el.setAttribute('aria-hidden', 'true')
 
-    // Ensure the previously focused element (if any) has a `focus` method
-    // before attempting to call it to account for SVG elements
-    // See: https://github.com/KittyGiraudel/a11y-dialog/issues/108
-    this.previouslyFocused?.focus?.()
-
     // Remove the focus event listener to the body element and stop listening
     // for specific key presses
     document.body.removeEventListener('focus', this.maintainFocus, true)
     this.$el.removeEventListener('keydown', this.bindKeypress, true)
+
+    // Ensure the previously focused element (if any) has a `focus` method
+    // before attempting to call it to account for SVG elements
+    // See: https://github.com/KittyGiraudel/a11y-dialog/issues/108
+    this.previouslyFocused?.focus?.()
 
     return this
   }


### PR DESCRIPTION
First, event handlers for maintaining focus and keyboard interaction are removed. Then, focus is restored to the previously focused element.